### PR TITLE
Update Terraform Configuration to Add XDM Servers, Adjust Elastic Pool Size, and Remove Microsoft Monitoring Agent

### DIFF
--- a/terraform/environments/prod/terraform.tfvars
+++ b/terraform/environments/prod/terraform.tfvars
@@ -336,10 +336,38 @@ device_manager_vm_details = {
     os_disk_type     = "Standard_LRS"
     vm_size          = "Standard_B4ms"
   },
+  "vmxwcdm05" = {
+    availability_zone = ["2"]
+    storage_data_disk = {
+      type = "Premium_LRS"
+      size = "256"
+    }
+    nic = {
+      subnet     = "snet-xwc-core-001"
+      ip_address = "10.192.30.34"
+    }
+    tag_update_class = "Gold1"
+    os_disk_type     = "Premium_LRS"
+    vm_size          = "Standard_D8s_V4"
+  },
+  "vmxwcdm06" = {
+    availability_zone = ["3"]
+    storage_data_disk = {
+      type = "Premium_LRS"
+      size = "256"
+    }
+    nic = {
+      subnet     = "snet-xwc-core-001"
+      ip_address = "10.192.30.35"
+    }
+    tag_update_class = "Gold1"
+    os_disk_type     = "Premium_LRS"
+    vm_size          = "Standard_D8s_V4"
+  },
 }
 environment          = "xwc"
 elastic_pool_name    = "xwc-prod-pool"
-e_pool_capacity      = 200
+e_pool_capacity      = 300
 key_vault_name       = "kv-xwc-coremoj-003"
 license_type         = "Windows_Server"
 location             = "UK South"

--- a/terraform/environments/prod/terraform.tfvars
+++ b/terraform/environments/prod/terraform.tfvars
@@ -360,7 +360,7 @@ device_manager_vm_details = {
       subnet     = "snet-xwc-core-001"
       ip_address = "10.192.30.35"
     }
-    tag_update_class = "Gold1"
+    tag_update_class = "Gold2"
     os_disk_type     = "Premium_LRS"
     vm_size          = "Standard_D8s_V4"
   },

--- a/terraform/modules/cloud-agent/virtual_machine.tf
+++ b/terraform/modules/cloud-agent/virtual_machine.tf
@@ -98,33 +98,6 @@ resource "azurerm_virtual_machine_extension" "AVEXT" {
   tags     = var.tags #This is to avoid terraform plan issues as the tags are applied by policy
 }
 
-
-resource "azurerm_virtual_machine_extension" "OMSAGENT" {
-  for_each                   = var.vm_details
-  name                       = "MicrosoftMonitoringAgent"
-  virtual_machine_id         = azurerm_virtual_machine.VM[each.key].id
-  publisher                  = "Microsoft.EnterpriseCloud.Monitoring"
-  type                       = "MicrosoftMonitoringAgent"
-  type_handler_version       = "1.0"
-  auto_upgrade_minor_version = true
-
-  settings = <<-BASE_SETTINGS
-  {
-    "azureResourceId" : "${azurerm_virtual_machine.VM[each.key].id}",
-    "stopOnMultipleConnections" : true,
-    "workspaceId" : "${data.azurerm_log_analytics_workspace.OMS_WORKSPACE.workspace_id}"
-  }
-  BASE_SETTINGS
-
-  protected_settings = <<-PROTECTED_SETTINGS
-  {
-    "workspaceKey" : "${data.azurerm_log_analytics_workspace.OMS_WORKSPACE.primary_shared_key}"
-  }
-  PROTECTED_SETTINGS
-
-  tags = var.tags #This is to avoid terraform plan issues as the tags are applied by policy
-}
-
 resource "azurerm_virtual_machine_extension" "login_for_windows" {
   for_each                   = var.vm_details
   name                       = "AADLoginForWindows"

--- a/terraform/modules/device-manager/virtual_machine.tf
+++ b/terraform/modules/device-manager/virtual_machine.tf
@@ -110,32 +110,6 @@ resource "azurerm_virtual_machine_extension" "AVEXT" {
 }
 
 
-resource "azurerm_virtual_machine_extension" "OMSAGENT" {
-  for_each                   = var.vm_details
-  name                       = "MicrosoftMonitoringAgent"
-  virtual_machine_id         = azurerm_virtual_machine.VM[each.key].id
-  publisher                  = "Microsoft.EnterpriseCloud.Monitoring"
-  type                       = "MicrosoftMonitoringAgent"
-  type_handler_version       = "1.0"
-  auto_upgrade_minor_version = true
-
-  settings = <<-BASE_SETTINGS
-  {
-    "azureResourceId" : "${azurerm_virtual_machine.VM[each.key].id}",
-    "stopOnMultipleConnections" : true,
-    "workspaceId" : "${data.azurerm_log_analytics_workspace.OMS_WORKSPACE.workspace_id}"
-  }
-  BASE_SETTINGS
-
-  protected_settings = <<-PROTECTED_SETTINGS
-  {
-    "workspaceKey" : "${data.azurerm_log_analytics_workspace.OMS_WORKSPACE.primary_shared_key}"
-  }
-  PROTECTED_SETTINGS
-
-  tags = var.tags #This is to avoid terraform plan issues as the tags are applied by policy
-}
-
 resource "azurerm_virtual_machine_extension" "login_for_windows" {
   for_each                   = var.vm_details
   name                       = "AADLoginForWindows"


### PR DESCRIPTION
This update includes several modifications to the Terraform code:

Addition of 2 New XDM Servers:

Two new XDM servers have been added, each with a distinct name, IP address, and availability zone.

These servers have a specific SKU configuration.

Elastic Pool Size Update:

The Elastic Pool EDTU has been increased from 200 to 300.

Removal of Microsoft Monitoring Agent:

The Microsoft Monitoring Agent has been removed from the Terraform configuration to prevent it from being reintroduced on agent and xdm servers by Terraform.

This change reflects the fact that the agent has already been removed from the servers in the Azure portal.

These changes ensure that the Terraform configuration aligns with current infrastructure and prevents the re-implementation of deprecated resources.