### PR TITLE
HC-1225 upgrade ubuntu vmimage to 24.04

### DIFF
--- a/pipelines/templates/template-terraform-deploy-stage.yml
+++ b/pipelines/templates/template-terraform-deploy-stage.yml
@@ -19,7 +19,7 @@ parameters:
   terraformOperation: "plan"
   terraformVersion: "1.5.7"
   workingDirectory: ""
-  vmImage: "ubuntu-20.04"
+  vmImage: "ubuntu-24.04"
   yamlenv: ""
 
 stages:


### PR DESCRIPTION
Upgrade the vmImage in Azure DevOps pipelines from **ubuntu-20.04** to **ubuntu-24.04** as per [HC-1225](https://dsdmoj.atlassian.net/browse/HC-1225) and this Microsoft deprecation warning: [aka.ms/azdo-ubuntu-20.04](https://aka.ms/azdo-ubuntu-20.04)

[HC-1225]: https://dsdmoj.atlassian.net/browse/HC-1225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ